### PR TITLE
Updates README due to branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Have you had a good experience with this project? Why not share some love and co
 We welcome issue reports [here](../../issues); be sure to choose the proper issue template for your issue, so that we can be sure you're providing the necessary information.
 
 Before sending a [Pull Request](../../pulls), please make sure you read our
-[Contribution Guidelines](https://github.com/bloomberg/.github/blob/master/CONTRIBUTING.md).
+[Contribution Guidelines](https://github.com/bloomberg/.github/blob/main/CONTRIBUTING.md).
 
 ## License
 
@@ -115,7 +115,7 @@ Please read the [LICENSE](LICENSE) file.
 
 ## Code of Conduct
 
-This project has adopted a [Code of Conduct](https://github.com/bloomberg/.github/blob/master/CODE_OF_CONDUCT.md).
+This project has adopted a [Code of Conduct](https://github.com/bloomberg/.github/blob/main/CODE_OF_CONDUCT.md).
 If you have any concerns about the Code, or behavior which you have experienced in the project, please
 contact us at opensource@bloomberg.net.
 


### PR DESCRIPTION
This updates a link in the README file due to a branch rename in https://github.com/bloomberg/.github.